### PR TITLE
#5 Preserve recyclerview position from single recyclerview

### DIFF
--- a/app/src/main/java/agency/digitera/android/promdate/ui/SinglesTabFragment.kt
+++ b/app/src/main/java/agency/digitera/android/promdate/ui/SinglesTabFragment.kt
@@ -86,9 +86,9 @@ class SinglesTabFragment : Fragment(), TabInterface {
 
     override fun onPause() {
         super.onPause()
-        if ((recyclerView.layoutManager as LinearLayoutManager).findFirstCompletelyVisibleItemPosition() > 0)
-            firstVisiblePos =
-                (recyclerView.layoutManager as LinearLayoutManager).findFirstCompletelyVisibleItemPosition()
+        val firstPosition = (recyclerView.layoutManager as LinearLayoutManager).findFirstCompletelyVisibleItemPosition()
+        if (firstPosition > 0)
+            firstVisiblePos = firstPosition
     }
 
     override fun invalidate() {


### PR DESCRIPTION
Since you're working with fragments and tabs, the override method `onSaveInstanceState` isn't called for a navigation. So, this is why wasn't working. Instead, I overrided the lifecycle method `onPause`, and when the item is clicked, there's a new variable in the fragment that saves the first complete item visible in the list, and than restaure the scroll.