### PR TITLE
#7 Make settings have (+) buttons for different social media

### DIFF
--- a/app/src/main/java/agency/digitera/android/promdate/adapters/SocialAdapter.kt
+++ b/app/src/main/java/agency/digitera/android/promdate/adapters/SocialAdapter.kt
@@ -13,7 +13,7 @@ import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.item_social.view.*
 
 class SocialAdapter(
-    private val list: List<UserSocial>?
+    private val list: MutableList<UserSocial>
 ) : RecyclerView.Adapter<SocialAdapter.ViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -22,27 +22,41 @@ class SocialAdapter(
         return ViewHolder(view)
     }
 
-    override fun getItemCount(): Int = list?.size ?: 0
+    override fun getItemCount(): Int = list.size
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(userSocial = list?.get(position))
+        holder.bind(userSocial = list[position])
     }
 
+    fun addSocialAccount(account: UserSocial) {
+        list.add(account)
+        notifyDataSetChanged()
+    }
+
+    fun getSocialList(): List<UserSocial> = list
 
     class ViewHolder(private val view: View) : RecyclerView.ViewHolder(view) {
-        fun bind(userSocial: UserSocial?) {
-            userSocial?.let {
+        fun bind(userSocial: UserSocial) {
+
+            if (!userSocial.nameSocial?.isBlank()!!) {
+
                 when (userSocial.socialMedia) {
                     INSTAGRAM -> {
+                        view.social_image.visibility = View.VISIBLE
+                        view.social_edit_wrapper.visibility = View.VISIBLE
+
                         view.social_image.setImageDrawable(
                             ContextCompat.getDrawable(
                                 view.context,
                                 R.drawable.instagram_logo
                             )
                         )
-                        view.social_edit.setText(it.nameSocial)
+                        view.social_edit.setText(userSocial.nameSocial)
                     }
                     SNAPCHAT -> {
+                        view.social_image.visibility = View.VISIBLE
+                        view.social_edit_wrapper.visibility = View.VISIBLE
+
                         view.social_image.setImageDrawable(
                             ContextCompat.getDrawable(
                                 view.context,
@@ -50,16 +64,19 @@ class SocialAdapter(
                             )
                         )
                         view.social_edit.setCompoundDrawables(null, null, null, null)
-                        view.social_edit.setText(it.nameSocial)
+                        view.social_edit.setText(userSocial.nameSocial)
                     }
                     TWITTER -> {
+                        view.social_image.visibility = View.VISIBLE
+                        view.social_edit_wrapper.visibility = View.VISIBLE
+
                         view.social_image.setImageDrawable(
                             ContextCompat.getDrawable(
                                 view.context,
                                 R.drawable.twitter_logo
                             )
                         )
-                        view.social_edit.setText(it.nameSocial)
+                        view.social_edit.setText(userSocial.nameSocial)
                     }
                 }
             }

--- a/app/src/main/java/agency/digitera/android/promdate/adapters/SocialAdapter.kt
+++ b/app/src/main/java/agency/digitera/android/promdate/adapters/SocialAdapter.kt
@@ -1,0 +1,68 @@
+package agency.digitera.android.promdate.adapters
+
+import agency.digitera.android.promdate.R
+import agency.digitera.android.promdate.data.INSTAGRAM
+import agency.digitera.android.promdate.data.SNAPCHAT
+import agency.digitera.android.promdate.data.TWITTER
+import agency.digitera.android.promdate.data.UserSocial
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.android.synthetic.main.item_social.view.*
+
+class SocialAdapter(
+    private val list: List<UserSocial>?
+) : RecyclerView.Adapter<SocialAdapter.ViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val view = inflater.inflate(R.layout.item_social, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun getItemCount(): Int = list?.size ?: 0
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(userSocial = list?.get(position))
+    }
+
+
+    class ViewHolder(private val view: View) : RecyclerView.ViewHolder(view) {
+        fun bind(userSocial: UserSocial?) {
+            userSocial?.let {
+                when (userSocial.socialMedia) {
+                    INSTAGRAM -> {
+                        view.social_image.setImageDrawable(
+                            ContextCompat.getDrawable(
+                                view.context,
+                                R.drawable.instagram_logo
+                            )
+                        )
+                        view.social_edit.setText(it.nameSocial)
+                    }
+                    SNAPCHAT -> {
+                        view.social_image.setImageDrawable(
+                            ContextCompat.getDrawable(
+                                view.context,
+                                R.drawable.snapchat_logo
+                            )
+                        )
+                        view.social_edit.setCompoundDrawables(null, null, null, null)
+                        view.social_edit.setText(it.nameSocial)
+                    }
+                    TWITTER -> {
+                        view.social_image.setImageDrawable(
+                            ContextCompat.getDrawable(
+                                view.context,
+                                R.drawable.twitter_logo
+                            )
+                        )
+                        view.social_edit.setText(it.nameSocial)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/agency/digitera/android/promdate/data/UserSocial.kt
+++ b/app/src/main/java/agency/digitera/android/promdate/data/UserSocial.kt
@@ -1,0 +1,10 @@
+package agency.digitera.android.promdate.data
+
+const val INSTAGRAM = 0
+const val SNAPCHAT = 1
+const val TWITTER = 2
+
+data class UserSocial(
+    val socialMedia: Int,
+    val nameSocial: String? = null
+)

--- a/app/src/main/java/agency/digitera/android/promdate/ui/SettingsFragment.kt
+++ b/app/src/main/java/agency/digitera/android/promdate/ui/SettingsFragment.kt
@@ -71,7 +71,11 @@ class SettingsFragment : Fragment() {
         setHasOptionsMenu(true)
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
         drawerInterface.lockDrawer()
         return inflater.inflate(R.layout.fragment_settings, container, false)
     }
@@ -123,6 +127,8 @@ class SettingsFragment : Fragment() {
 
         //load data
         loadData()
+
+        fab_add_social_media.setOnClickListener { openSocialMediaDialog() }
     }
 
     override fun onDestroyView() {
@@ -145,7 +151,10 @@ class SettingsFragment : Fragment() {
 
         //get token
         val sp: SharedPreferences =
-            context?.getSharedPreferences(getString(R.string.preference_file_key), Context.MODE_PRIVATE) ?: throw MissingSpException()
+            context?.getSharedPreferences(
+                getString(R.string.preference_file_key),
+                Context.MODE_PRIVATE
+            ) ?: throw MissingSpException()
         val token = sp.getString("token", null) ?: ""
 
         //send request
@@ -211,7 +220,11 @@ class SettingsFragment : Fragment() {
                     if (user.partner != null) {
                         unmatch_partner_button.visibility = View.VISIBLE
                         current_partner_text.visibility = View.VISIBLE
-                        current_partner_text.text = getString(R.string.currently_matched, user.partner?.firstName, user.partner?.lastName)
+                        current_partner_text.text = getString(
+                            R.string.currently_matched,
+                            user.partner?.firstName,
+                            user.partner?.lastName
+                        )
 
                         unmatch_partner_button.setOnClickListener {
                             unmatch(user.partner?.id ?: -1)
@@ -233,7 +246,10 @@ class SettingsFragment : Fragment() {
         //unmatch current partner
         val api = ApiAccessor().apiService
         val sp: SharedPreferences? =
-            context?.getSharedPreferences(getString(R.string.preference_file_key), Context.MODE_PRIVATE)
+            context?.getSharedPreferences(
+                getString(R.string.preference_file_key),
+                Context.MODE_PRIVATE
+            )
         val token = sp?.getString("token", null) ?: ""
 
         api.matchUser(token, partnerId, 1)
@@ -251,7 +267,10 @@ class SettingsFragment : Fragment() {
                     ).show()
                 }
 
-                override fun onResponse(call: Call<DefaultResponse>, response: Response<DefaultResponse>) {
+                override fun onResponse(
+                    call: Call<DefaultResponse>,
+                    response: Response<DefaultResponse>
+                ) {
                     if (response.body()?.status != 200) { //something went wrong, but server received request
                         //Match request failed
                         Log.e("MatchUser", "${response.body()?.status}: ${response.body()?.result}")
@@ -311,7 +330,10 @@ class SettingsFragment : Fragment() {
         val apiAccessor = ApiAccessor()
 
         val sp: SharedPreferences =
-            context?.getSharedPreferences(getString(R.string.preference_file_key), Context.MODE_PRIVATE) ?: throw MissingSpException()
+            context?.getSharedPreferences(
+                getString(R.string.preference_file_key),
+                Context.MODE_PRIVATE
+            ) ?: throw MissingSpException()
         val token = sp.getString("token", null) ?: ""
 
         //new profile picture
@@ -321,25 +343,45 @@ class SettingsFragment : Fragment() {
 
             // MultipartBody.Part is used to send also the actual file name
             MultipartBody.Part.createFormData("img", file.name, requestFile)
-        }
-        else {
+        } else {
             null
         }
 
         val bodyToken = RequestBody.create(MediaType.parse("multipart/form-data"), token)
-        val bodyInsta = RequestBody.create(MediaType.parse("multipart/form-data"), updatedUser.instagram ?: "")
-        val bodySnap = RequestBody.create(MediaType.parse("multipart/form-data"), updatedUser.snapchat ?: "")
-        val bodyTwitter = RequestBody.create(MediaType.parse("multipart/form-data"), updatedUser.twitter ?: "")
-        val bodyBio = RequestBody.create(MediaType.parse("multipart/form-data"), updatedUser.bio ?: "")
-        val bodyFirst = RequestBody.create(MediaType.parse("multipart/form-data"), updatedUser.firstName)
-        val bodyLast = RequestBody.create(MediaType.parse("multipart/form-data"), updatedUser.lastName)
-        val bodySchool = RequestBody.create(MediaType.parse("multipart/form-data"), updatedUser.schoolId.toString())
-        val bodyGrade = RequestBody.create(MediaType.parse("multipart/form-data"), updatedUser.grade.toString())
-        val bodyGender = RequestBody.create(MediaType.parse("multipart/form-data"), updatedUser.gender ?: "")
+        val bodyInsta =
+            RequestBody.create(MediaType.parse("multipart/form-data"), updatedUser.instagram ?: "")
+        val bodySnap =
+            RequestBody.create(MediaType.parse("multipart/form-data"), updatedUser.snapchat ?: "")
+        val bodyTwitter =
+            RequestBody.create(MediaType.parse("multipart/form-data"), updatedUser.twitter ?: "")
+        val bodyBio =
+            RequestBody.create(MediaType.parse("multipart/form-data"), updatedUser.bio ?: "")
+        val bodyFirst =
+            RequestBody.create(MediaType.parse("multipart/form-data"), updatedUser.firstName)
+        val bodyLast =
+            RequestBody.create(MediaType.parse("multipart/form-data"), updatedUser.lastName)
+        val bodySchool = RequestBody.create(
+            MediaType.parse("multipart/form-data"),
+            updatedUser.schoolId.toString()
+        )
+        val bodyGrade =
+            RequestBody.create(MediaType.parse("multipart/form-data"), updatedUser.grade.toString())
+        val bodyGender =
+            RequestBody.create(MediaType.parse("multipart/form-data"), updatedUser.gender ?: "")
 
         //create request
         val call: Call<UpdateResponse> = apiAccessor.apiService.updateUser(
-            bodyToken, bodyInsta, bodySnap, bodyTwitter, bodyBio, bodyFirst, bodyLast, bodySchool, bodyGrade, bodyGender, bodyImage
+            bodyToken,
+            bodyInsta,
+            bodySnap,
+            bodyTwitter,
+            bodyBio,
+            bodyFirst,
+            bodyLast,
+            bodySchool,
+            bodyGrade,
+            bodyGender,
+            bodyImage
         )
 
         val loadingAnim = loading_pb
@@ -347,7 +389,10 @@ class SettingsFragment : Fragment() {
 
         //send request
         call.enqueue(object : Callback<UpdateResponse> {
-            override fun onResponse(call: Call<UpdateResponse>, response: Response<UpdateResponse>) {
+            override fun onResponse(
+                call: Call<UpdateResponse>,
+                response: Response<UpdateResponse>
+            ) {
                 loadingAnim.visibility = View.GONE
 
                 if (response.body()?.status != 200) {
@@ -356,8 +401,7 @@ class SettingsFragment : Fragment() {
                         R.string.server_error,
                         Snackbar.LENGTH_LONG
                     ).show()
-                }
-                else {
+                } else {
                     AsyncTask.execute {
                         (activity as MainActivity).singlesDb.singleDao().updateUser(updatedUser)
                     }
@@ -379,8 +423,7 @@ class SettingsFragment : Fragment() {
     private fun isValidName(name: String): Boolean {
         if (name.isEmpty()) {
             return false
-        }
-        else {
+        } else {
             for (i in 0 until name.length) {
                 if (name[i] != ' ' && name[i] != '\n') {
                     return true
@@ -406,8 +449,7 @@ class SettingsFragment : Fragment() {
         else if (requestCode == UCrop.REQUEST_CROP && resultCode == RESULT_OK) {
             profilePicUri = UCrop.getOutput(data!!)
             showImage(profilePicUri!!)
-        }
-        else if (requestCode == UCrop.REQUEST_CROP && resultCode != RESULT_CANCELED) {
+        } else if (requestCode == UCrop.REQUEST_CROP && resultCode != RESULT_CANCELED) {
             //error cropping image
             val cropError = UCrop.getError(data!!)
             if (cropError != null) {
@@ -416,26 +458,26 @@ class SettingsFragment : Fragment() {
             } else {
                 Toast.makeText(context, "Unexpected error", Toast.LENGTH_SHORT).show()
             }
-        }
-        else {
+        } else {
             super.onActivityResult(requestCode, resultCode, data)
         }
     }
 
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
         if (requestCode == REQUEST_CAMERA) {
             if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                 openCamera()
-            }
-            else {
+            } else {
                 snackbar("PromDate requires camera access in order to take a photo.")
             }
-        }
-        else if (requestCode == REQUEST_EXTERNAL_STORAGE){
+        } else if (requestCode == REQUEST_EXTERNAL_STORAGE) {
             if (grantResults[0] == PackageManager.PERMISSION_GRANTED && grantResults[1] == PackageManager.PERMISSION_GRANTED) {
                 openGallery()
-            }
-            else {
+            } else {
                 snackbar("PromDate requires storage and camera access in order to select a photo from gallery.")
             }
         }
@@ -473,7 +515,8 @@ class SettingsFragment : Fragment() {
     private fun getImageFile(): File {
         // Create an image file name
         val timeStamp: String = SimpleDateFormat("yyyyMMdd_HHmmss").format(Date())
-        val storageDir: File = context?.getExternalFilesDir(Environment.DIRECTORY_PICTURES) ?: throw Exception("Context not found")
+        val storageDir: File = context?.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
+            ?: throw Exception("Context not found")
         return File.createTempFile(
             "JPEG_${timeStamp}_", /* prefix */
             ".jpg", /* suffix */
@@ -485,7 +528,11 @@ class SettingsFragment : Fragment() {
     }
 
     private fun openCamera() {
-        if (ContextCompat.checkSelfPermission(context!!, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+        if (ContextCompat.checkSelfPermission(
+                context!!,
+                Manifest.permission.CAMERA
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
             requestPermissions(
                 PERMISSIONS_CAMERA,
                 REQUEST_CAMERA
@@ -521,8 +568,15 @@ class SettingsFragment : Fragment() {
     }
 
     private fun openGallery() {
-        if (ContextCompat.checkSelfPermission(context!!, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED ||
-            ContextCompat.checkSelfPermission(context!!, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+        if (ContextCompat.checkSelfPermission(
+                context!!,
+                Manifest.permission.READ_EXTERNAL_STORAGE
+            ) != PackageManager.PERMISSION_GRANTED ||
+            ContextCompat.checkSelfPermission(
+                context!!,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
 
             requestPermissions(
                 PERMISSIONS_STORAGE,
@@ -531,7 +585,8 @@ class SettingsFragment : Fragment() {
             return
         }
         val pickPhoto = Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
-        startActivityForResult(pickPhoto,
+        startActivityForResult(
+            pickPhoto,
             PICK_IMAGE_GALLERY_REQUEST_CODE
         )
     }
@@ -566,13 +621,39 @@ class SettingsFragment : Fragment() {
         }
     }
 
+    private fun openSocialMediaDialog() {
+        val selectSocialAccount = SocialMediaDialogFragment()
+
+        val onSocialMediaSelected = fun(id: Int) {
+            selectSocialAccount.dismiss()
+            SocialMediaTagDialogFragment(id).show(
+                fragmentManager ?: throw Exception("Fragment manager not found"),
+                "social_media_tag_dialog_fragment"
+            )
+        }
+
+        selectSocialAccount.apply {
+            onSocialMediaClicked = onSocialMediaSelected
+        }.show(
+            fragmentManager ?: throw Exception("Fragment manager not found"),
+            "social_media_dialog_fragment"
+        )
+    }
+
+    private fun openSocialTag(onSocialMediaClicked: (Int) -> Unit) {
+
+    }
+
     companion object {
         private const val PICK_IMAGE_CAMERA_REQUEST_CODE = 610
         private const val PICK_IMAGE_GALLERY_REQUEST_CODE = 609
         private const val REQUEST_EXTERNAL_STORAGE = 0
         private const val REQUEST_CAMERA = 1
         private val PERMISSIONS_STORAGE =
-            arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            arrayOf(
+                Manifest.permission.READ_EXTERNAL_STORAGE,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+            )
         private val PERMISSIONS_CAMERA = arrayOf(Manifest.permission.CAMERA)
     }
 }

--- a/app/src/main/java/agency/digitera/android/promdate/ui/SettingsFragment.kt
+++ b/app/src/main/java/agency/digitera/android/promdate/ui/SettingsFragment.kt
@@ -1,46 +1,48 @@
 package agency.digitera.android.promdate.ui
 
+import agency.digitera.android.promdate.DrawerInterface
+import agency.digitera.android.promdate.MainActivity
+import agency.digitera.android.promdate.R
+import agency.digitera.android.promdate.data.*
+import agency.digitera.android.promdate.util.*
 import android.Manifest
 import android.app.Activity
+import android.app.Activity.RESULT_CANCELED
 import android.app.Activity.RESULT_OK
 import android.content.Context
+import android.content.Intent
 import android.content.SharedPreferences
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.AsyncTask
 import android.os.Build
 import android.os.Bundle
+import android.os.Environment
+import android.provider.MediaStore
 import android.util.Log
 import android.view.*
 import android.view.inputmethod.InputMethodManager
 import android.widget.Spinner
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
-import androidx.fragment.app.Fragment
-import agency.digitera.android.promdate.*
-import agency.digitera.android.promdate.data.*
-import com.google.android.material.snackbar.Snackbar
-import com.squareup.picasso.Picasso
-import kotlinx.android.synthetic.main.fragment_settings.*
-import retrofit2.Call
-import retrofit2.Callback
-import retrofit2.Response
-import java.lang.NumberFormatException
-import android.provider.MediaStore
 import androidx.core.content.FileProvider
-import android.content.Intent
-import android.content.pm.PackageManager
-import android.net.Uri
-import android.os.Environment
 import androidx.core.net.toFile
-import agency.digitera.android.promdate.util.*
-import android.app.Activity.RESULT_CANCELED
-import android.os.AsyncTask
-import android.widget.Toast
+import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import com.google.android.material.snackbar.Snackbar
 import com.squareup.picasso.MemoryPolicy
+import com.squareup.picasso.Picasso
 import com.yalantis.ucrop.UCrop
+import kotlinx.android.synthetic.main.fragment_settings.*
+import kotlinx.android.synthetic.main.user_info.view.*
 import okhttp3.MediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
 import java.io.File
 import java.io.IOException
 import java.text.SimpleDateFormat
@@ -115,7 +117,7 @@ class SettingsFragment : Fragment() {
         gradeSpinner.setSelection(gradeAdapter.count)
 
         //set up change profile picture
-        profile_picture_image.setOnClickListener {
+        include_user_info.profile_picture_image.setOnClickListener {
             showImagePickerDialog()
         }
 
@@ -175,10 +177,15 @@ class SettingsFragment : Fragment() {
 
                     //set up user profile with user's information
                     if (user.self.profilePictureUrl.isNotEmpty()) {
-                        LoadUrl.loadProfilePicture(context!!, profile_picture_image, user.self.profilePictureUrl, 1)
+                        LoadUrl.loadProfilePicture(
+                            context!!,
+                            include_user_info.profile_picture_image,
+                            user.self.profilePictureUrl,
+                            1
+                        )
                     }
-                    first_name_edit.setText(user.self.firstName)
-                    last_name_edit.setText(user.self.lastName)
+                    include_user_info.first_name_edit.setText(user.self.firstName)
+                    include_user_info.last_name_edit.setText(user.self.lastName)
                     school_edit.setText(user.school.name)
                     //set grade
                     val gradeId = user.self.grade?.minus(9) ?: -1
@@ -197,9 +204,9 @@ class SettingsFragment : Fragment() {
                         else -> gender_spinner.setSelection(3)
                     }
 
-                    instagram_edit.setText(user.self.instagram)
-                    snapchat_edit.setText(user.self.snapchat)
-                    twitter_edit.setText(user.self.twitter)
+//                    instagram_edit.setText(user.self.instagram)
+//                    snapchat_edit.setText(user.self.snapchat)
+//                    twitter_edit.setText(user.self.twitter)
 
                     if (user.partner != null) {
                         unmatch_partner_button.visibility = View.VISIBLE
@@ -264,12 +271,12 @@ class SettingsFragment : Fragment() {
 
     private fun updateUser() {
         val updatedUser = User()
-        updatedUser.firstName = first_name_edit.text.toString()
-        updatedUser.lastName = last_name_edit.text.toString()
+        updatedUser.firstName = include_user_info.first_name_edit.text.toString()
+        updatedUser.lastName = include_user_info.last_name_edit.text.toString()
         updatedUser.bio = bio_edit.text.toString()
-        updatedUser.snapchat = snapchat_edit.text.toString()
-        updatedUser.instagram = instagram_edit.text.toString()
-        updatedUser.twitter = twitter_edit.text.toString()
+//        updatedUser.snapchat = snapchat_edit.text.toString()
+//        updatedUser.instagram = instagram_edit.text.toString()
+//        updatedUser.twitter = twitter_edit.text.toString()
         updatedUser.schoolId = 1
         updatedUser.grade = try {
             grade_spinner.selectedItem.toString().toInt()
@@ -281,16 +288,16 @@ class SettingsFragment : Fragment() {
         //check that all required fields are there & valid
         var missingFields = false
         if (!isValidName(updatedUser.firstName)) {
-            first_name_edit_wrapper.error = getString(R.string.invalid_name)
+            include_user_info.first_name_edit_wrapper.error = getString(R.string.invalid_name)
             missingFields = true
         } else {
-            first_name_edit_wrapper.error = null
+            include_user_info.first_name_edit_wrapper.error = null
         }
         if (!isValidName(updatedUser.lastName)) {
-            last_name_edit_wrapper.error = getString(R.string.invalid_name)
+            include_user_info.last_name_edit_wrapper.error = getString(R.string.invalid_name)
             missingFields = true
         } else {
-            last_name_edit_wrapper.error = null
+            include_user_info.last_name_edit_wrapper.error = null
         }
         if (updatedUser.schoolId < 0) {
             missingFields = true
@@ -452,7 +459,7 @@ class SettingsFragment : Fragment() {
             .memoryPolicy(MemoryPolicy.NO_CACHE)
             .placeholder(R.drawable.default_profile) //TODO: Change to loading animation
             .error(R.drawable.default_profile) //TODO: Change to actual error
-            .into(profile_picture_image)
+            .into(include_user_info.profile_picture_image)
     }
 
     private fun openCropActivity(sourceUri: Uri) {

--- a/app/src/main/java/agency/digitera/android/promdate/ui/SettingsFragment.kt
+++ b/app/src/main/java/agency/digitera/android/promdate/ui/SettingsFragment.kt
@@ -3,6 +3,7 @@ package agency.digitera.android.promdate.ui
 import agency.digitera.android.promdate.DrawerInterface
 import agency.digitera.android.promdate.MainActivity
 import agency.digitera.android.promdate.R
+import agency.digitera.android.promdate.adapters.SocialAdapter
 import agency.digitera.android.promdate.data.*
 import agency.digitera.android.promdate.util.*
 import android.Manifest
@@ -31,6 +32,7 @@ import androidx.core.content.FileProvider
 import androidx.core.net.toFile
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import com.squareup.picasso.MemoryPolicy
 import com.squareup.picasso.Picasso
@@ -95,6 +97,7 @@ class SettingsFragment : Fragment() {
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)
         }
+
 
         //set up gender spinner with hint
         val genderOptions: Array<String> = resources.getStringArray(R.array.genders_array)
@@ -213,9 +216,17 @@ class SettingsFragment : Fragment() {
                         else -> gender_spinner.setSelection(3)
                     }
 
-//                    instagram_edit.setText(user.self.instagram)
-//                    snapchat_edit.setText(user.self.snapchat)
-//                    twitter_edit.setText(user.self.twitter)
+                    val listSocialMedias = listOf(
+                        UserSocial(INSTAGRAM, user.self.instagram),
+                        UserSocial(SNAPCHAT, user.self.snapchat),
+                        UserSocial(TWITTER, user.self.twitter)
+                    )
+
+                    //set up social media recycler view
+                    list_social_media.apply {
+                        layoutManager = LinearLayoutManager(context)
+                        adapter = SocialAdapter(listSocialMedias)
+                    }
 
                     if (user.partner != null) {
                         unmatch_partner_button.visibility = View.VISIBLE
@@ -638,10 +649,6 @@ class SettingsFragment : Fragment() {
             fragmentManager ?: throw Exception("Fragment manager not found"),
             "social_media_dialog_fragment"
         )
-    }
-
-    private fun openSocialTag(onSocialMediaClicked: (Int) -> Unit) {
-
     }
 
     companion object {

--- a/app/src/main/java/agency/digitera/android/promdate/ui/SocialMediaDialogFragment.kt
+++ b/app/src/main/java/agency/digitera/android/promdate/ui/SocialMediaDialogFragment.kt
@@ -1,0 +1,36 @@
+package agency.digitera.android.promdate.ui
+
+import agency.digitera.android.promdate.R
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import kotlinx.android.synthetic.main.dialog_social_media.*
+
+class SocialMediaDialogFragment : BottomSheetDialogFragment(), View.OnClickListener {
+
+    var onSocialMediaClicked: (Int) -> Unit = {}
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? =
+        inflater.inflate(
+            R.layout.dialog_social_media, container,
+            false
+        )
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        instagram.setOnClickListener(this)
+        snapchat.setOnClickListener(this)
+        twitter.setOnClickListener(this)
+    }
+
+    override fun onClick(view: View) {
+        onSocialMediaClicked(view.id)
+    }
+
+}

--- a/app/src/main/java/agency/digitera/android/promdate/ui/SocialMediaDialogFragment.kt
+++ b/app/src/main/java/agency/digitera/android/promdate/ui/SocialMediaDialogFragment.kt
@@ -31,6 +31,7 @@ class SocialMediaDialogFragment : BottomSheetDialogFragment(), View.OnClickListe
 
     override fun onClick(view: View) {
         onSocialMediaClicked(view.id)
+        dismiss()
     }
 
 }

--- a/app/src/main/java/agency/digitera/android/promdate/ui/SocialMediaTagDialogFragment.kt
+++ b/app/src/main/java/agency/digitera/android/promdate/ui/SocialMediaTagDialogFragment.kt
@@ -1,6 +1,10 @@
 package agency.digitera.android.promdate.ui
 
 import agency.digitera.android.promdate.R
+import agency.digitera.android.promdate.data.INSTAGRAM
+import agency.digitera.android.promdate.data.SNAPCHAT
+import agency.digitera.android.promdate.data.TWITTER
+import agency.digitera.android.promdate.data.UserSocial
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -10,6 +14,8 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import kotlinx.android.synthetic.main.dialog_social_media_tag.*
 
 class SocialMediaTagDialogFragment(private val idSocialMedia: Int) : BottomSheetDialogFragment() {
+
+    var onClickAddAccount: (UserSocial) -> Unit = {}
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -53,6 +59,31 @@ class SocialMediaTagDialogFragment(private val idSocialMedia: Int) : BottomSheet
                 )
                 social_media_edit.hint = resources.getString(R.string.twitter)
             }
+        }
+
+        addButton.setOnClickListener {
+            when (idSocialMedia) {
+                R.id.instagram -> onClickAddAccount(
+                    UserSocial(
+                        INSTAGRAM,
+                        social_media_edit.text.toString()
+                    )
+                )
+                R.id.snapchat -> onClickAddAccount(
+                    UserSocial(
+                        SNAPCHAT,
+                        social_media_edit.text.toString()
+                    )
+                )
+                R.id.twitter -> onClickAddAccount(
+                    UserSocial(
+                        TWITTER,
+                        social_media_edit.text.toString()
+                    )
+                )
+            }
+
+            dismiss()
         }
     }
 }

--- a/app/src/main/java/agency/digitera/android/promdate/ui/SocialMediaTagDialogFragment.kt
+++ b/app/src/main/java/agency/digitera/android/promdate/ui/SocialMediaTagDialogFragment.kt
@@ -1,0 +1,58 @@
+package agency.digitera.android.promdate.ui
+
+import agency.digitera.android.promdate.R
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import kotlinx.android.synthetic.main.dialog_social_media_tag.*
+
+class SocialMediaTagDialogFragment(private val idSocialMedia: Int) : BottomSheetDialogFragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? =
+        inflater.inflate(
+            R.layout.dialog_social_media_tag, container,
+            false
+        )
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        when (idSocialMedia) {
+            R.id.instagram -> {
+                social_media_image.setImageDrawable(
+                    ContextCompat.getDrawable(
+                        requireContext(),
+                        R.drawable.instagram_logo
+                    )
+                )
+                social_media_edit.hint = resources.getString(R.string.twitter)
+            }
+            R.id.snapchat -> {
+                social_media_image.setImageDrawable(
+                    ContextCompat.getDrawable(
+                        requireContext(),
+                        R.drawable.snapchat_logo
+                    )
+                )
+                social_media_edit.setCompoundDrawables(null, null, null, null)
+                social_media_edit.hint = resources.getString(R.string.snapchat)
+            }
+            R.id.twitter -> {
+                social_media_image.setImageDrawable(
+                    ContextCompat.getDrawable(
+                        requireContext(),
+                        R.drawable.twitter_logo
+                    )
+                )
+                social_media_edit.hint = resources.getString(R.string.twitter)
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/dialog_social_media.xml
+++ b/app/src/main/res/layout/dialog_social_media.xml
@@ -9,18 +9,6 @@
     android:background="@drawable/rounded_dialog"
     android:orientation="vertical">
 
-    <View
-        android:id="@+id/divider1"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/lightGray" />
-
-    <View
-        android:id="@+id/divider2"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/lightGray" />
-
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/snapchat"
         android:layout_width="match_parent"
@@ -58,6 +46,12 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
+    <View
+        android:id="@+id/divider1"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/lightGray" />
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/instagram"
         android:layout_width="match_parent"
@@ -94,6 +88,12 @@
             app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <View
+        android:id="@+id/divider2"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/lightGray" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/twitter"

--- a/app/src/main/res/layout/dialog_social_media.xml
+++ b/app/src/main/res/layout/dialog_social_media.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/linear_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginLeft="25dp"
+    android:layout_marginRight="25dp"
+    android:background="@drawable/rounded_dialog"
+    android:orientation="vertical">
+
+    <View
+        android:id="@+id/divider1"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/lightGray" />
+
+    <View
+        android:id="@+id/divider2"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/lightGray" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/snapchat"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true">
+
+        <ImageView
+            android:id="@+id/snapchat_image"
+            android:layout_width="48dp"
+            android:layout_height="50dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/snapchat_logo" />
+
+        <TextView
+            android:id="@+id/snapchat_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginBottom="8dp"
+            android:text="Snapchat"
+            android:textSize="20sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/snapchat_image"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/instagram"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true">
+
+        <ImageView
+            android:id="@+id/instagram_image"
+            android:layout_width="48dp"
+            android:layout_height="50dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/instagram_logo" />
+
+        <TextView
+            android:id="@+id/instagram_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginBottom="8dp"
+            android:text="Instagram"
+            android:textSize="20sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/instagram_image"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/twitter"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true">
+
+        <ImageView
+            android:id="@+id/twitter_image"
+            android:layout_width="48dp"
+            android:layout_height="50dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/twitter_logo" />
+
+        <TextView
+            android:id="@+id/twitter_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginBottom="8dp"
+            android:text="Twitter"
+            android:textSize="20sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/twitter_image"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_social_media_tag.xml
+++ b/app/src/main/res/layout/dialog_social_media_tag.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="AppBottomSheetDialogTheme"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+
+    <ImageView
+        android:id="@+id/social_media_image"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="center_vertical"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:adjustViewBounds="true"
+        app:layout_constraintBottom_toBottomOf="@+id/social_media_wrapper"
+        app:layout_constraintEnd_toStartOf="@+id/social_media_wrapper"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:srcCompat="@drawable/instagram_logo" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/addButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="8dp"
+        android:padding="8dp"
+        android:text="Add"
+        android:textColor="@color/colorPrimary"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/social_media_wrapper"
+        tools:text="Add" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/social_media_wrapper"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:layout_margin="8dp"
+        android:layout_marginTop="@dimen/vertical_spacing"
+        android:layout_marginEnd="8dp"
+        app:errorEnabled="false"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@+id/social_media_image"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/social_media_edit"
+            style="@style/loginEditText"
+            android:drawableStart="@drawable/at_sign"
+            android:maxLength="30"
+            android:theme="@style/EditText"
+            tools:hint="@string/instagram" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -15,7 +15,7 @@
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:fillViewport="true">
 
         <androidx.constraintlayout.widget.ConstraintLayout
@@ -127,6 +127,20 @@
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintWidth_percent="0.25" />
 
+            <TextView
+                android:id="@+id/current_partner_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="@string/currently_matched"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="@+id/unmatch_partner_button"
+                app:layout_constraintEnd_toStartOf="@+id/unmatch_partner_button"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/unmatch_partner_button"
+                tools:visibility="visible" />
+
             <Button
                 android:id="@+id/unmatch_partner_button"
                 style="@style/Widget.AppCompat.Button"
@@ -145,19 +159,14 @@
                 app:layout_constraintTop_toBottomOf="@+id/gender_spinner"
                 tools:visibility="visible" />
 
-            <TextView
-                android:id="@+id/current_partner_text"
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/fab_add_social_media"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:text="@string/currently_matched"
-                android:visibility="gone"
-                app:layout_constraintBottom_toBottomOf="@+id/unmatch_partner_button"
-                app:layout_constraintEnd_toStartOf="@+id/unmatch_partner_button"
-                app:layout_constraintHorizontal_bias="0.5"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/unmatch_partner_button"
-                tools:visibility="visible" />
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="16dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -23,67 +23,13 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <ImageView
-                android:id="@+id/profile_picture_image"
-                android:layout_width="100dp"
-                android:layout_height="0dp"
-                android:layout_marginStart="@dimen/edge_margin"
-                android:layout_marginBottom="@dimen/vertical_spacing"
-                android:adjustViewBounds="true"
+            <include
+                android:id="@+id/include_user_info"
+                layout="@layout/user_info"
+                app:layout_constraintBottom_toTopOf="@+id/bio_edit_wrapper"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@id/first_name_edit_wrapper"
-                app:layout_constraintBottom_toTopOf="@id/bio_edit_wrapper"
-                app:srcCompat="@drawable/default_profile" />
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/first_name_edit_wrapper"
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/horizontal_spacing"
-                android:layout_marginTop="@dimen/edge_margin"
-                android:layout_marginEnd="@dimen/edge_margin"
-                app:errorEnabled="false"
-                app:layout_constraintBottom_toTopOf="@id/last_name_edit_wrapper"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/profile_picture_image"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_chainStyle="packed">
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/first_name_edit"
-                    style="@style/loginEditText"
-                    android:hint="@string/first_name"
-                    android:inputType="textPersonName"
-                    android:maxLength="190"
-                    android:theme="@style/EditText"
-                    tools:text="John" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/last_name_edit_wrapper"
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/horizontal_spacing"
-                android:layout_marginTop="@dimen/vertical_spacing"
-                android:layout_marginEnd="@dimen/edge_margin"
-                android:layout_marginBottom="@dimen/vertical_spacing"
-                app:errorEnabled="false"
-                app:layout_constraintBottom_toBottomOf="@+id/profile_picture_image"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/profile_picture_image"
-                app:layout_constraintTop_toBottomOf="@id/first_name_edit_wrapper">
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/last_name_edit"
-                    style="@style/loginEditText"
-                    android:hint="@string/last_name"
-                    android:inputType="textPersonName"
-                    android:maxLength="190"
-                    android:theme="@style/EditText"
-                    tools:text="Smith" />
-            </com.google.android.material.textfield.TextInputLayout>
+                app:layout_constraintTop_toTopOf="parent" />
 
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/bio_edit_wrapper"
@@ -94,9 +40,10 @@
                 android:layout_marginTop="@dimen/vertical_spacing"
                 android:layout_marginEnd="@dimen/edge_margin"
                 app:errorEnabled="false"
+                app:layout_constraintBottom_toTopOf="@+id/list_social_media"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/last_name_edit_wrapper">
+                app:layout_constraintTop_toBottomOf="@+id/include_user_info">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/bio_edit"
@@ -108,109 +55,14 @@
                     tools:text="I'm an incredibly intelligent individual. Please do not attempt to match with me if your IQ is below 150." />
             </com.google.android.material.textfield.TextInputLayout>
 
-            <ImageView
-                android:id="@+id/instagram_image"
-                android:layout_width="48dp"
-                android:layout_height="0dp"
-                android:layout_marginStart="@dimen/edge_margin"
-                android:layout_marginTop="@dimen/vertical_spacing"
-                android:adjustViewBounds="true"
-                app:layout_constraintBottom_toBottomOf="@+id/instagram_edit_wrapper"
-                app:layout_constraintEnd_toStartOf="@id/instagram_edit_wrapper"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/instagram_edit_wrapper"
-                app:srcCompat="@drawable/instagram_logo" />
-
-            <ImageView
-                android:id="@+id/snapchat_image"
-                android:layout_width="48dp"
-                android:layout_height="0dp"
-                android:layout_marginStart="@dimen/edge_margin"
-                android:layout_marginTop="@dimen/vertical_spacing"
-                android:adjustViewBounds="true"
-                app:layout_constraintBottom_toBottomOf="@+id/snapchat_edit_wrapper"
-                app:layout_constraintEnd_toStartOf="@id/snapchat_edit_wrapper"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/snapchat_edit_wrapper"
-                app:srcCompat="@drawable/snapchat_logo" />
-
-            <ImageView
-                android:id="@+id/twitter_image"
-                android:layout_width="48dp"
-                android:layout_height="0dp"
-                android:layout_marginStart="@dimen/edge_margin"
-                android:layout_marginTop="@dimen/vertical_spacing"
-                android:layout_marginBottom="@dimen/vertical_spacing"
-                android:adjustViewBounds="true"
-                app:layout_constraintBottom_toBottomOf="@+id/twitter_edit_wrapper"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/twitter_edit_wrapper"
-                app:srcCompat="@drawable/twitter_logo" />
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/instagram_edit_wrapper"
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/list_social_media"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/horizontal_spacing"
-                android:layout_marginTop="@dimen/vertical_spacing"
-                android:layout_marginEnd="@dimen/edge_margin"
-                app:errorEnabled="false"
+                app:layout_constraintBottom_toTopOf="@+id/school_edit_wrapper"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/instagram_image"
-                app:layout_constraintTop_toBottomOf="@+id/bio_edit_wrapper">
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/instagram_edit"
-                    style="@style/loginEditText"
-                    android:drawableStart="@drawable/at_sign"
-                    android:hint="@string/instagram"
-                    android:maxLength="30"
-                    android:theme="@style/EditText" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/snapchat_edit_wrapper"
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/horizontal_spacing"
-                android:layout_marginTop="@dimen/small_vertical_spacing"
-                android:layout_marginEnd="@dimen/edge_margin"
-                app:errorEnabled="false"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/snapchat_image"
-                app:layout_constraintTop_toBottomOf="@+id/instagram_edit_wrapper">
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/snapchat_edit"
-                    style="@style/loginEditText"
-                    android:hint="@string/snapchat"
-                    android:maxLength="15"
-                    android:theme="@style/EditText" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/twitter_edit_wrapper"
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/horizontal_spacing"
-                android:layout_marginTop="@dimen/small_vertical_spacing"
-                android:layout_marginEnd="@dimen/edge_margin"
-                app:errorEnabled="false"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/twitter_image"
-                app:layout_constraintTop_toBottomOf="@+id/snapchat_edit_wrapper">
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/twitter_edit"
-                    style="@style/loginEditText"
-                    android:drawableStart="@drawable/at_sign"
-                    android:hint="@string/twitter"
-                    android:maxLength="15"
-                    android:theme="@style/EditText" />
-            </com.google.android.material.textfield.TextInputLayout>
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/bio_edit_wrapper" />
 
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/school_edit_wrapper"
@@ -222,8 +74,9 @@
                 android:layout_marginEnd="@dimen/edge_margin"
                 app:errorEnabled="true"
                 app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.5"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/twitter_edit_wrapper">
+                app:layout_constraintTop_toBottomOf="@+id/list_social_media">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/school_edit"
@@ -238,10 +91,10 @@
                 android:layout_width="0dp"
                 android:layout_height="32dp"
                 android:layout_marginStart="@dimen/edge_margin"
-                android:layout_marginTop="@dimen/small_vertical_spacing"
+                android:layout_marginTop="8dp"
                 android:prompt="@string/select_gender"
                 app:layout_constraintEnd_toStartOf="@+id/grade_spinner"
-                app:layout_constraintHorizontal_chainStyle="packed"
+                app:layout_constraintHorizontal_bias="0.5"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/school_edit_wrapper" />
 
@@ -250,39 +103,13 @@
                 android:layout_width="0dp"
                 android:layout_height="32dp"
                 android:layout_marginStart="@dimen/horizontal_spacing"
+                android:layout_marginTop="8dp"
                 android:layout_marginEnd="@dimen/edge_margin"
                 android:prompt="@string/select_grade"
                 app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.5"
                 app:layout_constraintStart_toEndOf="@+id/gender_spinner"
-                app:layout_constraintTop_toTopOf="@+id/gender_spinner" />
-
-            <TextView
-                android:id="@+id/current_partner_text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:text="@string/currently_matched"
-                android:visibility="gone"
-                app:layout_constraintBottom_toBottomOf="@+id/unmatch_partner_button"
-                app:layout_constraintEnd_toStartOf="@+id/unmatch_partner_button"
-                app:layout_constraintHorizontal_bias="0.5"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/unmatch_partner_button" />
-
-            <Button
-                android:id="@+id/unmatch_partner_button"
-                style="@style/Widget.AppCompat.Button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:fontFamily="sans-serif-medium"
-                android:text="@string/remove"
-                android:textSize="14sp"
-                android:visibility="gone"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.5"
-                app:layout_constraintStart_toEndOf="@+id/current_partner_text"
-                app:layout_constraintTop_toBottomOf="@+id/gender_spinner" />
+                app:layout_constraintTop_toBottomOf="@+id/school_edit_wrapper" />
 
             <ProgressBar
                 android:id="@+id/loading_pb"
@@ -299,6 +126,39 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintWidth_percent="0.25" />
+
+            <Button
+                android:id="@+id/unmatch_partner_button"
+                style="@style/Widget.AppCompat.Button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="8dp"
+                android:fontFamily="sans-serif-medium"
+                android:text="@string/remove"
+                android:textSize="14sp"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toEndOf="@+id/current_partner_text"
+                app:layout_constraintTop_toBottomOf="@+id/gender_spinner"
+                tools:visibility="visible" />
+
+            <TextView
+                android:id="@+id/current_partner_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="@string/currently_matched"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="@+id/unmatch_partner_button"
+                app:layout_constraintEnd_toStartOf="@+id/unmatch_partner_button"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/unmatch_partner_button"
+                tools:visibility="visible" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 </LinearLayout>

--- a/app/src/main/res/layout/item_social.xml
+++ b/app/src/main/res/layout/item_social.xml
@@ -33,6 +33,7 @@
             style="@style/loginEditText"
             android:drawableStart="@drawable/at_sign"
             android:maxLength="30"
+            android:focusable="false"
             android:inputType="textPersonName"
             android:theme="@style/EditText" />
     </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/layout/item_social.xml
+++ b/app/src/main/res/layout/item_social.xml
@@ -11,28 +11,30 @@
         android:layout_height="48dp"
         android:layout_gravity="center_vertical"
         android:layout_margin="8dp"
+        android:visibility="gone"
         android:layout_marginStart="@dimen/edge_margin"
         android:layout_marginTop="@dimen/vertical_spacing"
         android:adjustViewBounds="true"
         tools:src="@drawable/instagram_logo" />
 
     <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/instagram_edit_wrapper"
+        android:id="@+id/social_edit_wrapper"
         style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="8dp"
         android:layout_marginStart="@dimen/horizontal_spacing"
         android:layout_marginTop="@dimen/vertical_spacing"
-        android:layout_marginEnd="@dimen/edge_margin">
+        android:layout_marginEnd="@dimen/edge_margin"
+        android:visibility="gone">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/social_edit"
             style="@style/loginEditText"
             android:drawableStart="@drawable/at_sign"
             android:maxLength="30"
+            android:inputType="textPersonName"
             android:theme="@style/EditText" />
-
     </com.google.android.material.textfield.TextInputLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/item_social.xml
+++ b/app/src/main/res/layout/item_social.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+
+    <ImageView
+        android:id="@+id/social_image"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="center_vertical"
+        android:layout_margin="8dp"
+        android:layout_marginStart="@dimen/edge_margin"
+        android:layout_marginTop="@dimen/vertical_spacing"
+        android:adjustViewBounds="true"
+        tools:src="@drawable/instagram_logo" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/instagram_edit_wrapper"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:layout_marginStart="@dimen/horizontal_spacing"
+        android:layout_marginTop="@dimen/vertical_spacing"
+        android:layout_marginEnd="@dimen/edge_margin">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/social_edit"
+            style="@style/loginEditText"
+            android:drawableStart="@drawable/at_sign"
+            android:maxLength="30"
+            android:theme="@style/EditText" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/user_info.xml
+++ b/app/src/main/res/layout/user_info.xml
@@ -22,7 +22,7 @@
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/first_name_edit_wrapper"
         style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-        android:layout_width="271dp"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
@@ -46,7 +46,7 @@
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/last_name_edit_wrapper"
         style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-        android:layout_width="271dp"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:layout_marginEnd="16dp"

--- a/app/src/main/res/layout/user_info.xml
+++ b/app/src/main/res/layout/user_info.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <ImageView
+        android:id="@+id/profile_picture_image"
+        android:layout_width="100dp"
+        android:layout_height="0dp"
+        android:layout_marginStart="@dimen/edge_margin"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:adjustViewBounds="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/default_profile" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/first_name_edit_wrapper"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="271dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        app:errorEnabled="false"
+        app:layout_constraintBottom_toTopOf="@+id/last_name_edit_wrapper"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/profile_picture_image"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/first_name_edit"
+            style="@style/loginEditText"
+            android:hint="@string/first_name"
+            android:inputType="textPersonName"
+            android:maxLength="190"
+            android:theme="@style/EditText"
+            tools:text="John" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/last_name_edit_wrapper"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="271dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="8dp"
+        app:errorEnabled="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/profile_picture_image"
+        app:layout_constraintTop_toBottomOf="@+id/first_name_edit_wrapper">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/last_name_edit"
+            style="@style/loginEditText"
+            android:hint="@string/last_name"
+            android:inputType="textPersonName"
+            android:maxLength="190"
+            android:theme="@style/EditText"
+            tools:text="Smith" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Firstly, I removed all the `social components` from the `settings_page`. To make it cleaner, the photo, first and last name, moved to another `layout` and make an include of it. Added a `recycler_view` now that the social tags are loaded as a `list`. Added a `floating_action_button` that's open a `dialog` for the user choose how nick of what social media he whant's to share and after, put in it and added to the list. Once that everything is setted, the user save.